### PR TITLE
Add Cyrillic characters transliteration.

### DIFF
--- a/firmware/application/lib/utils.h
+++ b/firmware/application/lib/utils.h
@@ -40,4 +40,5 @@ void UtilsSetRPORMode(uint8_t, uint16_t);
 unsigned char UtilsStrToHex(char *);
 uint8_t UtilsStrToInt(char *);
 int8_t UtilsStricmp(const char *, const char *);
+const char* TransliterateUnicodeToExtendedASCII(uint32_t);
 #endif /* UTILS_H */


### PR DESCRIPTION
1. Parsing of Unicode characters has been improved. Now it's possible to read 1-4 bytes characters.
2. Cyrillic Unicode characters are mapped to corresponding Latin representation.

Example:
source bytes: \D0\97\D0\B2\D0\B5\D0\B7\D0\B4\D0\B0 \D0\BF\D0\BE \D0\B8\D0\BC\D0\B5\D0\BD\D0\B8 \D0\A1\D0\BE\D0\BB\D0\BD\D1\86\D0\B5
output: Zvyezda po imeni Solntsye