### PR TITLE
Prevent CRC calculation including uninitialised memory

### DIFF
--- a/firmware/bootloader/lib/protocol.c
+++ b/firmware/bootloader/lib/protocol.c
@@ -308,7 +308,7 @@ void ProtocolSendPacket(
     }
     uint8_t i;
     unsigned char crc = 0x00;
-    for (i = 0; i < length; i++) {
+    for (i = 0; i < length - 1; i++) {
         crc ^= (unsigned char) packet[i];
     }
     packet[length - 1] = crc;


### PR DESCRIPTION
The current CRC calculation includes the array position of the CRC byte (i.e. the last byte of the array) in its calculation.
This can be uninitialised memory, and if it's non-zero, will throw off the calculated CRC.
I've updated the CRC calculation to CRC the packet bytes up to the last byte.