### PR TITLE
Advanced comfort blinkers.

### DIFF
--- a/firmware/application/handler.c
+++ b/firmware/application/handler.c
@@ -142,11 +142,6 @@ void HandlerInit(BC127_t *bt, IBus_t *ibus)
         &Context
     );
     EventRegisterCallback(
-        IBusEvent_LCMDiagnosticsAcknowledge,
-        &HandlerIBusLMDiagnosticsAcknowledge,
-        &Context
-    );
-    EventRegisterCallback(
         IBusEvent_LCMDimmerStatus,
         &HandlerIBusLMDimmerStatus,
         &Context
@@ -1136,82 +1131,191 @@ void HandlerIBusLMIdentResponse(void *ctx, unsigned char *variant)
  */
 void HandlerIBusLMLightStatus(void *ctx, unsigned char *pkt)
 {
-    uint8_t blinkCount = ConfigGetSetting(CONFIG_SETTING_COMFORT_BLINKERS);
-    if (blinkCount > 0x01 && blinkCount != 0xFF) {
+    // Changed identifier as to not confuse it with the blink counter.
+    uint8_t configBlinkLimit = ConfigGetSetting(CONFIG_SETTING_COMFORT_BLINKERS);
+
+    if (configBlinkLimit > 1) {
         HandlerContext_t *context = (HandlerContext_t *) ctx;
         unsigned char lightStatus = pkt[4];
-        if (context->lightControlStatus.lightStatus == HANDLER_LCM_STATUS_BLINKER_OFF) {
-            context->lightControlStatus.blinkCount = 2;
-            if (CHECK_BIT(lightStatus, IBUS_LM_LEFT_SIG_BIT) != 0 &&
-                CHECK_BIT(lightStatus, IBUS_LM_RIGHT_SIG_BIT) == 0
-            ) {
-                context->lightControlStatus.leftBlinker = 1;
-                context->lightControlStatus.lightStatus = HANDLER_LCM_STATUS_BLINKER_ON;
-                IBusCommandLMActivateBulbs(context->ibus, IBUS_LM_BLINKER_LEFT);
-            } else if (CHECK_BIT(lightStatus, IBUS_LM_RIGHT_SIG_BIT) != 0 &&
-                CHECK_BIT(lightStatus, IBUS_LM_LEFT_SIG_BIT) == 0
-            ) {
-                context->lightControlStatus.rightBlinker = 1;
-                context->lightControlStatus.lightStatus = HANDLER_LCM_STATUS_BLINKER_ON;
-                IBusCommandLMActivateBulbs(context->ibus, IBUS_LM_BLINKER_RIGHT);
-            }
-        } else {
-            if (context->lightControlStatus.leftBlinker == 1) {
-                if (CHECK_BIT(lightStatus, IBUS_LM_RIGHT_SIG_BIT) != 0 ||
-                    context->lightControlStatus.blinkCount == blinkCount
-                ) {
-                    // Reset ourselves once the signal is off so we do not
-                    // reactivate and signal in increments of `blinkCount`
-                    if (CHECK_BIT(lightStatus, IBUS_LM_LEFT_SIG_BIT) == 0) {
-                        context->lightControlStatus.leftBlinker = 0;
-                        context->lightControlStatus.lightStatus = HANDLER_LCM_STATUS_BLINKER_OFF;
-                    }
-                    if (context->lightControlStatus.triggerStatus == HANDLER_LCM_TRIGGER_ON) {
-                        IBusCommandDIATerminateDiag(context->ibus, IBUS_DEVICE_LCM);
-                    }
-                } else {
-                    context->lightControlStatus.blinkCount++;
-                }
-            }
-            if (context->lightControlStatus.rightBlinker == 1) {
-                if (CHECK_BIT(lightStatus, IBUS_LM_LEFT_SIG_BIT) != 0 ||
-                    context->lightControlStatus.blinkCount == blinkCount
-                ) {
-                    // Reset ourselves once the signal is off so we do not
-                    // reactivate and signal in increments of `blinkCount`
-                    if (CHECK_BIT(lightStatus, IBUS_LM_RIGHT_SIG_BIT) == 0) {
-                        context->lightControlStatus.rightBlinker = 0;
-                        context->lightControlStatus.lightStatus = HANDLER_LCM_STATUS_BLINKER_OFF;
-                    }
-                    if (context->lightControlStatus.triggerStatus == HANDLER_LCM_TRIGGER_ON) {
-                        IBusCommandDIATerminateDiag(context->ibus, IBUS_DEVICE_LCM);
-                    }
-                } else {
-                    context->lightControlStatus.blinkCount++;
-                }
-            }
-        }
-    }
-}
+        unsigned char lightStatus2 = pkt[6];
 
-/**
- * HandlerIBusLCMDiagnosticsAcknowledge()
- *     Description:
- *         Track when the LCM acknowledges a diagnostic command
- *     Params:
- *         void *ctx - The context provided at registration
- *         unsigned char *tmp - Any event data
- *     Returns:
- *         void
- */
-void HandlerIBusLMDiagnosticsAcknowledge(void *ctx, unsigned char *pkt)
-{
-    HandlerContext_t *context = (HandlerContext_t *) ctx;
-    if (context->lightControlStatus.lightStatus == HANDLER_LCM_STATUS_BLINKER_ON) {
-        if (context->lightControlStatus.triggerStatus == HANDLER_LCM_TRIGGER_ON) {
-            context->lightControlStatus.triggerStatus = HANDLER_LCM_TRIGGER_OFF;
-        } else {
-            context->lightControlStatus.triggerStatus = HANDLER_LCM_TRIGGER_ON;
+        // Left blinker
+        if (CHECK_BIT(lightStatus, IBUS_LM_LEFT_SIG_BIT) != 0 &&
+            CHECK_BIT(lightStatus, IBUS_LM_RIGHT_SIG_BIT) == 0 &&
+            CHECK_BIT(lightStatus2, IBUS_LM_BLINK_SIG_BIT) != 0
+        ) {
+            // If quickly switching blinker direction the LM will activate the
+            // opposing blinker immediately, bypassing the "off" message.
+            if (context->lightControlStatus.blinkStatus == HANDLER_LM_BLINK_RIGHT) {
+                LogDebug(CONFIG_DEVICE_LOG_SYSTEM, "LEFT > Quick Switch > Reset");
+                context->lightControlStatus.blinkCount = 0;
+            }
+            context->lightControlStatus.blinkCount++;
+            context->lightControlStatus.blinkStatus = HANDLER_LM_BLINK_LEFT;
+
+            switch (context->lightControlStatus.comfortStatus) {
+                case HANDLER_LM_COMF_BLINK_INACTIVE:
+                    LogDebug(
+                        CONFIG_DEVICE_LOG_SYSTEM,
+                        "LEFT > COMFORT_INACTIVE > %hhu/%hhu",
+                        context->lightControlStatus.blinkCount,
+                        configBlinkLimit
+                    );
+                    break;
+                case HANDLER_LM_COMF_BLINK_LEFT:
+                    LogDebug(
+                        CONFIG_DEVICE_LOG_SYSTEM,
+                        "LEFT > COMFORT_LEFT > %hhu/%hhu",
+                        context->lightControlStatus.blinkCount,
+                        configBlinkLimit
+                    );
+                    if (context->lightControlStatus.blinkCount >= configBlinkLimit) {
+                        LogDebug(
+                            CONFIG_DEVICE_LOG_SYSTEM,
+                            "LEFT > COMFORT_LEFT > Blink limit"
+                        );
+                        context->lightControlStatus.comfortStatus = HANDLER_LM_COMF_BLINK_INACTIVE;
+                        IBusCommandLMActivateBulbs(context->ibus, IBUS_LM_BLINKER_OFF);
+                    }
+                    break;
+                case HANDLER_LM_COMF_BLINK_RIGHT:
+                    LogDebug(
+                        CONFIG_DEVICE_LOG_SYSTEM,
+                        "LEFT > COMFORT_RIGHT > Cancel"
+                    );
+                    // If comfort blinkers are active, the first opposing blink
+                    // will cancel comfort blinkers, and not count towards the blink count.
+                    context->lightControlStatus.blinkCount = 0;
+                    context->lightControlStatus.comfortStatus = HANDLER_LM_COMF_BLINK_INACTIVE;
+                    IBusCommandLMActivateBulbs(context->ibus, IBUS_LM_BLINKER_OFF);
+                    break;
+                default:
+                    LogDebug(CONFIG_DEVICE_LOG_SYSTEM, "LEFT > Unknown State");
+                    break;
+            }
+        } else if (CHECK_BIT(lightStatus, IBUS_LM_LEFT_SIG_BIT) != 0 &&
+                   CHECK_BIT(lightStatus, IBUS_LM_RIGHT_SIG_BIT) == 0 &&
+                   CHECK_BIT(lightStatus2, IBUS_LM_BLINK_SIG_BIT) == 0
+        ) {
+            LogDebug(CONFIG_DEVICE_LOG_SYSTEM, "LEFT > Unrelated activity");
+        } else if (CHECK_BIT(lightStatus, IBUS_LM_LEFT_SIG_BIT) == 0 &&
+                  CHECK_BIT(lightStatus, IBUS_LM_RIGHT_SIG_BIT) != 0 &&
+                  CHECK_BIT(lightStatus2, IBUS_LM_BLINK_SIG_BIT) != 0
+        ) {
+            if (context->lightControlStatus.blinkStatus == HANDLER_LM_BLINK_LEFT) {
+                LogDebug(CONFIG_DEVICE_LOG_SYSTEM, "RIGHT > Quick Switch > Reset");
+                context->lightControlStatus.blinkCount = 0;
+            }
+            context->lightControlStatus.blinkCount++;
+            context->lightControlStatus.blinkStatus = HANDLER_LM_BLINK_RIGHT;
+            switch (context->lightControlStatus.comfortStatus) {
+                case HANDLER_LM_COMF_BLINK_INACTIVE:
+                    LogDebug(
+                        CONFIG_DEVICE_LOG_SYSTEM,
+                        "RIGHT > COMFORT_INACTIVE > %hhu/%hhu",
+                        context->lightControlStatus.blinkCount,
+                        configBlinkLimit
+                    );
+                    break;
+                case HANDLER_LM_COMF_BLINK_RIGHT:
+                    LogDebug(
+                        CONFIG_DEVICE_LOG_SYSTEM,
+                        "RIGHT > COMFORT_RIGHT > %hhu/%hhu",
+                        context->lightControlStatus.blinkCount,
+                        configBlinkLimit
+                    );
+                    if(context->lightControlStatus.blinkCount >= configBlinkLimit) {
+                        LogDebug(
+                            CONFIG_DEVICE_LOG_SYSTEM,
+                            "RIGHT > COMFORT_RIGHT > Blink limit"
+                        );
+                        context->lightControlStatus.comfortStatus = HANDLER_LM_COMF_BLINK_INACTIVE;
+                        IBusCommandLMActivateBulbs(context->ibus, IBUS_LM_BLINKER_OFF);
+                    }
+                    break;
+                case HANDLER_LM_COMF_BLINK_LEFT:
+                    LogDebug(
+                        CONFIG_DEVICE_LOG_SYSTEM,
+                        "RIGHT > COMFORT_LEFT > Cancel"
+                    );
+                    context->lightControlStatus.blinkCount = 0;
+                    context->lightControlStatus.comfortStatus = HANDLER_LM_COMF_BLINK_INACTIVE;
+                    IBusCommandLMActivateBulbs(context->ibus, IBUS_LM_BLINKER_OFF);
+                    break;
+                default:
+                    LogDebug(CONFIG_DEVICE_LOG_SYSTEM, "RIGHT > Unknown State");
+                    break;
+            }
+        } else if (CHECK_BIT(lightStatus, IBUS_LM_LEFT_SIG_BIT) == 0 &&
+                   CHECK_BIT(lightStatus, IBUS_LM_RIGHT_SIG_BIT) != 0 &&
+                   CHECK_BIT(lightStatus2, IBUS_LM_BLINK_SIG_BIT) == 0
+        ) {
+            LogDebug(CONFIG_DEVICE_LOG_SYSTEM, "RIGHT > Unrelated activity");
+        } else if(CHECK_BIT(lightStatus, IBUS_LM_LEFT_SIG_BIT) == 0 &&
+                  CHECK_BIT(lightStatus, IBUS_LM_RIGHT_SIG_BIT) == 0
+        ) {
+            // OFF blinker (or anything non-blinker)
+            // Only activate comfort blinkers after a single blink.
+            if (context->lightControlStatus.blinkCount == 1) {
+                LogDebug(
+                    CONFIG_DEVICE_LOG_SYSTEM,
+                    "OFF > Blinks: %hhu => Activate",
+                    context->lightControlStatus.blinkCount
+                );
+                // I believe this is redundant, but better safe than sorry.
+                switch (context->lightControlStatus.comfortStatus) {
+                    case HANDLER_LM_COMF_BLINK_RIGHT:
+                        LogDebug(
+                            CONFIG_DEVICE_LOG_SYSTEM,
+                            "OFF > Blinks: %hhu > COMFORT_RIGHT > Cancel",
+                            context->lightControlStatus.blinkCount
+                        );
+                        context->lightControlStatus.comfortStatus = HANDLER_LM_COMF_BLINK_INACTIVE;
+                        IBusCommandLMActivateBulbs(context->ibus, IBUS_LM_BLINKER_OFF);
+                        break;
+                    case HANDLER_LM_COMF_BLINK_LEFT:
+                        LogDebug(
+                            CONFIG_DEVICE_LOG_SYSTEM,
+                            "OFF > Blinks: %hhu > COMFORT_LEFT > Cancel",
+                            context->lightControlStatus.blinkCount
+                        );
+                        context->lightControlStatus.comfortStatus = HANDLER_LM_COMF_BLINK_INACTIVE;
+                        IBusCommandLMActivateBulbs(context->ibus, IBUS_LM_BLINKER_OFF);
+                        break;
+                }
+                // Activate comfort
+                switch (context->lightControlStatus.blinkStatus) {
+                    case HANDLER_LM_BLINK_LEFT:
+                        LogDebug(
+                            CONFIG_DEVICE_LOG_SYSTEM,
+                            "OFF > Blinks: %hhu > BLINK_LEFT => Activate",
+                            context->lightControlStatus.blinkCount
+                        );
+                        context->lightControlStatus.comfortStatus = HANDLER_LM_COMF_BLINK_LEFT;
+                        IBusCommandLMActivateBulbs(context->ibus, IBUS_LM_BLINKER_LEFT);
+                        break;
+                    case HANDLER_LM_BLINK_RIGHT:
+                        LogDebug(
+                            CONFIG_DEVICE_LOG_SYSTEM,
+                            "OFF > Blinks: %hhu > BLINK_RIGHT => Activate",
+                            context->lightControlStatus.blinkCount
+                        );
+                        context->lightControlStatus.comfortStatus = HANDLER_LM_COMF_BLINK_RIGHT;
+                        IBusCommandLMActivateBulbs(context->ibus, IBUS_LM_BLINKER_RIGHT);
+                        break;
+                }
+            } else if (context->lightControlStatus.blinkCount > 1) {
+                LogDebug(
+                    CONFIG_DEVICE_LOG_SYSTEM,
+                    "OFF > Blinks: %hhu => Do not activate comfort",
+                    context->lightControlStatus.blinkCount
+                );
+                context->lightControlStatus.blinkCount = 0;
+            } else {
+                // Sequential non-blinker lamp activity
+                LogDebug(CONFIG_DEVICE_LOG_SYSTEM, "OFF > Unrelated activity!");
+            }
+            context->lightControlStatus.blinkStatus = HANDLER_LM_BLINK_OFF;
         }
     }
 }

--- a/firmware/application/handler.h
+++ b/firmware/application/handler.h
@@ -19,6 +19,12 @@
 #include "ui/mid.h"
 #define HANDLER_LCM_STATUS_BLINKER_OFF 0
 #define HANDLER_LCM_STATUS_BLINKER_ON 1
+#define HANDLER_LM_BLINK_OFF 0x00
+#define HANDLER_LM_BLINK_LEFT 0x01
+#define HANDLER_LM_BLINK_RIGHT 0x02
+#define HANDLER_LM_COMF_BLINK_INACTIVE 0x00
+#define HANDLER_LM_COMF_BLINK_LEFT 0x01
+#define HANDLER_LM_COMF_BLINK_RIGHT 0x02
 #define HANDLER_LCM_TRIGGER_OFF 0
 #define HANDLER_LCM_TRIGGER_ON 1
 #define HANDLER_BT_CONN_OFF 0
@@ -54,11 +60,9 @@ typedef struct HandlerBodyModuleStatus_t {
 } HandlerBodyModuleStatus_t;
 
 typedef struct HandlerLightControlStatus_t {
-    uint8_t lightStatus: 1;
-    uint8_t triggerStatus: 1;
-    uint8_t leftBlinker: 1;
-    uint8_t rightBlinker: 1;
-    uint8_t blinkCount: 4;
+    uint8_t blinkStatus: 2;
+    uint8_t blinkCount: 8;
+    uint8_t comfortStatus: 2;
 } HandlerLightControlStatus_t;
 
 typedef struct HandlerModuleStatus_t {
@@ -113,7 +117,6 @@ void HandlerIBusIKEIgnitionStatus(void *, unsigned char *);
 void HandlerIBusIKESpeedRPMUpdate(void *, unsigned char *);
 void HandlerIBusIKEVehicleType(void *, unsigned char *);
 void HandlerIBusLMLightStatus(void *, unsigned char *);
-void HandlerIBusLMDiagnosticsAcknowledge(void *, unsigned char *);
 void HandlerIBusLMDimmerStatus(void *, unsigned char *);
 void HandlerIBusLMIdentResponse(void *, unsigned char *);
 void HandlerIBusLMRedundantData(void *, unsigned char *);

--- a/firmware/application/lib/ibus.c
+++ b/firmware/application/lib/ibus.c
@@ -1764,7 +1764,6 @@ void IBusCommandIKETextClear(IBus_t *ibus)
  */
 void IBusCommandLMActivateBulbs(IBus_t *ibus, unsigned char blinkerSide) {
     unsigned char blinker = IBUS_LSZ_BLINKER_OFF;
-
     if (ibus->lmVariant == IBUS_LM_LME38) {
         switch (blinkerSide) {
             case IBUS_LM_BLINKER_LEFT:
@@ -1772,6 +1771,9 @@ void IBusCommandLMActivateBulbs(IBus_t *ibus, unsigned char blinkerSide) {
                 break;
             case IBUS_LM_BLINKER_RIGHT:
                 blinker = IBUS_LME38_BLINKER_RIGHT;
+                break;
+            case IBUS_LM_BLINKER_OFF:
+                blinker = IBUS_LME38_BLINKER_OFF;
                 break;
         }
         // No LWR load sensor/HVAC pot voltage for LME38
@@ -1806,6 +1808,9 @@ void IBusCommandLMActivateBulbs(IBus_t *ibus, unsigned char blinkerSide) {
                 break;
             case IBUS_LM_BLINKER_RIGHT:
                 blinker = IBUS_LCM_BLINKER_RIGHT;
+                break;
+            case IBUS_LM_BLINKER_OFF:
+                blinker = IBUS_LCM_BLINKER_OFF;
                 break;
         }
         // This is an issue! I'm not sure what differentiates S1 and S2.
@@ -1843,6 +1848,9 @@ void IBusCommandLMActivateBulbs(IBus_t *ibus, unsigned char blinkerSide) {
             case IBUS_LM_BLINKER_RIGHT:
                 blinker = IBUS_LCM_II_BLINKER_RIGHT;
                 break;
+            case IBUS_LM_BLINKER_OFF:
+                blinker = IBUS_LCM_II_BLINKER_OFF;
+                break;
         }
         unsigned char msg[] = {
             IBUS_CMD_DIA_JOB_REQUEST,
@@ -1876,6 +1884,9 @@ void IBusCommandLMActivateBulbs(IBus_t *ibus, unsigned char blinkerSide) {
                 break;
           case IBUS_LM_BLINKER_RIGHT:
                 blinker = IBUS_LSZ_BLINKER_RIGHT;
+                break;
+          case IBUS_LM_BLINKER_OFF:
+                blinker = IBUS_LSZ_BLINKER_OFF;
                 break;
         }
         unsigned char msg[] = {

--- a/firmware/application/lib/ibus.h
+++ b/firmware/application/lib/ibus.h
@@ -198,44 +198,51 @@
 #define IBUS_LCM_DIMMER_STATUS 0x5C
 #define IBUS_LCM_IO_STATUS 0x90
 
-// Lamp Status (0x5B)
+// Lamp Status (0x5B) L / R Lamp Byte = 0, Blink Byte = 2
 #define IBUS_LM_LEFT_SIG_BIT 5
 #define IBUS_LM_RIGHT_SIG_BIT 6
+#define IBUS_LM_BLINK_SIG_BIT 2
 
 // LM diagnostics activate (0x0C)
-#define IBUS_LM_BLINKER_LEFT 1 // PN convention, odd = left
-#define IBUS_LM_BLINKER_RIGHT 2 // PN convention, even = right
+#define IBUS_LM_BLINKER_OFF 0
+#define IBUS_LM_BLINKER_LEFT 1
+#define IBUS_LM_BLINKER_RIGHT 2
 
-// LME38
-#define IBUS_LME38_BLINKER_LEFT 0x01 // byte 0
-#define IBUS_LME38_BLINKER_RIGHT 0x02 // byte 0
+// LME38 (Byte 0)
+#define IBUS_LME38_BLINKER_OFF 0x00
+#define IBUS_LME38_BLINKER_LEFT 0x01
+#define IBUS_LME38_BLINKER_RIGHT 0x02
 
 // LCM, LCM_A
 // Different bytes! Update the blinker msg if alternating.
-// #define IBUS_LCM_BLINKER_LEFT 0x80 // byte 0 (S2_BLK_L	switch No.2 left turn)
-// #define IBUS_LCM_BLINKER_RIGHT 0x40 // byte 0 (S2_BLK_R	switch No.2 right turn)
-#define IBUS_LCM_BLINKER_LEFT 0x01 // byte 1 (S1_BLK_L	switch No.1 left turn)
-#define IBUS_LCM_BLINKER_RIGHT 0x02 // byte 1 (S1_BLK_R	switch No.1 right turn)
+// Byte 0 (S2_BLK_L switch No.2 left turn / S2_BLK_R switch No.2 right turn)
+// #define IBUS_LCM_BLINKER_LEFT 0x80 
+// #define IBUS_LCM_BLINKER_RIGHT 0x40
+// Byte 1 (S2_BLK_L switch No.1 left turn / S2_BLK_R switch No.1 right turn)
+#define IBUS_LCM_BLINKER_OFF 0x00
+#define IBUS_LCM_BLINKER_LEFT 0x01
+#define IBUS_LCM_BLINKER_RIGHT 0x02
 
-// LCM_II, LCM_III, LCM_IV
-#define IBUS_LCM_II_BLINKER_LEFT 0x80 // byte 2
-#define IBUS_LCM_II_BLINKER_RIGHT 0x40 // byte 2
+// LCM_II, LCM_III, LCM_IV (Byte 2)
+#define IBUS_LCM_II_BLINKER_OFF 0x00
+#define IBUS_LCM_II_BLINKER_LEFT 0x80
+#define IBUS_LCM_II_BLINKER_RIGHT 0x40
 
-// LSZ, LSZ_2
-#define IBUS_LSZ_HEADLIGHT_OFF 0xFF // byte 2
-#define IBUS_LSZ_BLINKER_LEFT 0x50 // byte 3
-#define IBUS_LSZ_BLINKER_RIGHT 0x80 // byte 3
-#define IBUS_LSZ_BLINKER_OFF 0xFF // byte 3
+// LSZ, LSZ_2 (Headlight Status = Byte 2, Blinker Status = Byte 3)
+#define IBUS_LSZ_HEADLIGHT_OFF 0xFF
+#define IBUS_LSZ_BLINKER_LEFT 0x50
+#define IBUS_LSZ_BLINKER_RIGHT 0x80
+#define IBUS_LSZ_BLINKER_OFF 0xFF
 
 // Ident (0x00) parameter offsets
 #define IBUS_LM_CI_ID_OFFSET 9
 #define IBUS_LM_DI_ID_OFFSET 10
-// Status (0x0b) parameter offsets
+// Status (0x0B) parameter offsets
 #define IBUS_LM_IO_LOAD_FRONT_OFFSET 11
 #define IBUS_LM_IO_DIMMER_OFFSET 19
 #define IBUS_LM_IO_LOAD_REAR_OFFSET 20
 #define IBUS_LM_IO_PHOTO_OFFSET 22
-// LME38 has unique mapping. Spoilt first child.
+// LME38 has unique mapping
 #define IBUS_LME38_IO_DIMMER_OFFSET 22
 
 // Light Module variants


### PR DESCRIPTION
* Activate comfort blinkers only after single blink/off cycle.
* Allow cancelling comfort blinkers via opposing blink.
* Deactivate comfort blinkers prior to activating opposing comfort blinkers to prevent the original switch input from becoming unresponsive.
* Filter concurrent non-blinker lamp events during comfort blinking to prevent artificially incrementing blinker count.
* Stop comfort blinkers via diagnostic activation, rather than diagnostic end.
* All LM variants now support diagnostic blinker deactivation.