### PR TITLE
Add Unicode Extended-latin characters transformation into ASCII for CallerID & Audio Metadata, do buffer overrun checks. 

### DIFF
--- a/firmware/application/lib/bc127.c
+++ b/firmware/application/lib/bc127.c
@@ -1215,13 +1215,13 @@ void BC127Process(BC127_t *bt)
                     // Remove the escaped quotes that come through
                     UtilsRemoveSubstring(cidDataBuf[0], "\\22");
                     // Clean the text up
-                    UtilsNormalizeText(callerId, cidDataBuf[0],BC127_CALLER_ID_FIELD_SIZE);
+                    UtilsNormalizeText(callerId, cidDataBuf[0], BC127_CALLER_ID_FIELD_SIZE);
                 } else {
                     if (cidDataBuf[cidDelimCounter - 1] != 0x00) {
                         // Remove the escaped quotes that come through
                         UtilsRemoveSubstring(cidDataBuf[cidDelimCounter - 1], "\\22");
                         // Clean the text up
-                        UtilsNormalizeText(callerId, cidDataBuf[cidDelimCounter - 1],BC127_CALLER_ID_FIELD_SIZE);
+                        UtilsNormalizeText(callerId, cidDataBuf[cidDelimCounter - 1], BC127_CALLER_ID_FIELD_SIZE);
                     }
                 }
                 if (strlen(callerId) > 0) {
@@ -1238,18 +1238,18 @@ void BC127Process(BC127_t *bt)
                 bt->metadataStatus = BC127_METADATA_STATUS_NEW;
                 char title[BC127_METADATA_MAX_SIZE];
                 memset(title, 0, BC127_METADATA_MAX_SIZE);
-                UtilsNormalizeText(title, &msg[BC127_METADATA_TITLE_OFFSET],BC127_METADATA_MAX_SIZE);
+                UtilsNormalizeText(title, &msg[BC127_METADATA_TITLE_OFFSET], BC127_METADATA_MAX_SIZE);
                 strncpy(bt->title, title, BC127_METADATA_FIELD_SIZE - 1);
             } else if (strcmp(msgBuf[2], "ARTIST:") == 0) {
                 char artist[BC127_METADATA_MAX_SIZE];
                 memset(artist, 0, BC127_METADATA_MAX_SIZE);
-                UtilsNormalizeText(artist, &msg[BC127_METADATA_ARTIST_OFFSET],BC127_METADATA_MAX_SIZE);
+                UtilsNormalizeText(artist, &msg[BC127_METADATA_ARTIST_OFFSET], BC127_METADATA_MAX_SIZE);
                 strncpy(bt->artist, artist, BC127_METADATA_FIELD_SIZE - 1);
             } else {
                 if (strcmp(msgBuf[2], "ALBUM:") == 0) {
                     char album[BC127_METADATA_MAX_SIZE];
                     memset(album, 0, BC127_METADATA_MAX_SIZE);
-                    UtilsNormalizeText(album, &msg[BC127_METADATA_ALBUM_OFFSET],BC127_METADATA_MAX_SIZE);
+                    UtilsNormalizeText(album, &msg[BC127_METADATA_ALBUM_OFFSET], BC127_METADATA_MAX_SIZE);
                     strncpy(bt->album, album, BC127_METADATA_FIELD_SIZE - 1);
                 }
                 if (bt->metadataStatus == BC127_METADATA_STATUS_NEW) {
@@ -1472,7 +1472,7 @@ void BC127Process(BC127_t *bt)
             deviceName[strIdx] = '\0';
             char name[BC127_DEVICE_NAME_LEN];
             memset(name, 0, BC127_DEVICE_NAME_LEN);
-            UtilsNormalizeText(name, deviceName,BC127_DEVICE_NAME_LEN);
+            UtilsNormalizeText(name, deviceName, BC127_DEVICE_NAME_LEN);
             if (strcmp(msgBuf[1], bt->activeDevice.macId) == 0) {
                 // Clean the device name up
                 memset(bt->activeDevice.deviceName, 0, BC127_DEVICE_NAME_LEN);

--- a/firmware/application/lib/bc127.c
+++ b/firmware/application/lib/bc127.c
@@ -1215,13 +1215,13 @@ void BC127Process(BC127_t *bt)
                     // Remove the escaped quotes that come through
                     UtilsRemoveSubstring(cidDataBuf[0], "\\22");
                     // Clean the text up
-                    UtilsNormalizeText(callerId, cidDataBuf[0]);
+                    UtilsNormalizeText(callerId, cidDataBuf[0],BC127_CALLER_ID_FIELD_SIZE);
                 } else {
                     if (cidDataBuf[cidDelimCounter - 1] != 0x00) {
                         // Remove the escaped quotes that come through
                         UtilsRemoveSubstring(cidDataBuf[cidDelimCounter - 1], "\\22");
                         // Clean the text up
-                        UtilsNormalizeText(callerId, cidDataBuf[cidDelimCounter - 1]);
+                        UtilsNormalizeText(callerId, cidDataBuf[cidDelimCounter - 1],BC127_CALLER_ID_FIELD_SIZE);
                     }
                 }
                 if (strlen(callerId) > 0) {
@@ -1238,18 +1238,18 @@ void BC127Process(BC127_t *bt)
                 bt->metadataStatus = BC127_METADATA_STATUS_NEW;
                 char title[BC127_METADATA_MAX_SIZE];
                 memset(title, 0, BC127_METADATA_MAX_SIZE);
-                UtilsNormalizeText(title, &msg[BC127_METADATA_TITLE_OFFSET]);
+                UtilsNormalizeText(title, &msg[BC127_METADATA_TITLE_OFFSET],BC127_METADATA_MAX_SIZE);
                 strncpy(bt->title, title, BC127_METADATA_FIELD_SIZE - 1);
             } else if (strcmp(msgBuf[2], "ARTIST:") == 0) {
                 char artist[BC127_METADATA_MAX_SIZE];
                 memset(artist, 0, BC127_METADATA_MAX_SIZE);
-                UtilsNormalizeText(artist, &msg[BC127_METADATA_ARTIST_OFFSET]);
+                UtilsNormalizeText(artist, &msg[BC127_METADATA_ARTIST_OFFSET],BC127_METADATA_MAX_SIZE);
                 strncpy(bt->artist, artist, BC127_METADATA_FIELD_SIZE - 1);
             } else {
                 if (strcmp(msgBuf[2], "ALBUM:") == 0) {
                     char album[BC127_METADATA_MAX_SIZE];
                     memset(album, 0, BC127_METADATA_MAX_SIZE);
-                    UtilsNormalizeText(album, &msg[BC127_METADATA_ALBUM_OFFSET]);
+                    UtilsNormalizeText(album, &msg[BC127_METADATA_ALBUM_OFFSET],BC127_METADATA_MAX_SIZE);
                     strncpy(bt->album, album, BC127_METADATA_FIELD_SIZE - 1);
                 }
                 if (bt->metadataStatus == BC127_METADATA_STATUS_NEW) {
@@ -1472,7 +1472,7 @@ void BC127Process(BC127_t *bt)
             deviceName[strIdx] = '\0';
             char name[BC127_DEVICE_NAME_LEN];
             memset(name, 0, BC127_DEVICE_NAME_LEN);
-            UtilsNormalizeText(name, deviceName);
+            UtilsNormalizeText(name, deviceName,BC127_DEVICE_NAME_LEN);
             if (strcmp(msgBuf[1], bt->activeDevice.macId) == 0) {
                 // Clean the device name up
                 memset(bt->activeDevice.deviceName, 0, BC127_DEVICE_NAME_LEN);

--- a/firmware/application/lib/utils.c
+++ b/firmware/application/lib/utils.c
@@ -81,7 +81,7 @@ UtilsAbstractDisplayValue_t UtilsDisplayValueInit(char *text, uint8_t status)
  *     Params:
  *         char *string - The subject
  *         const char *input - The string to copy from
- *         uint16_t max_len - Max output string size 
+ *         uint16_t max_len - Max output buffer size 
  *     Returns:
  *         void
  */
@@ -99,8 +99,7 @@ void UtilsNormalizeText(char *string, const char *input, uint16_t max_len)
     uint8_t bytesInChar = 0;
     unsigned char language = ConfigGetSetting(CONFIG_SETTING_LANGUAGE);
 
-    for (idx = 0; idx < strLength; idx++) {
-        if (strIdx+1>=max_len) break;
+    for (idx = 0; (idx < strLength) && (strIdx<(max_len-1)); idx++) {
         uint8_t currentChar = (uint8_t) input[idx];
         unicodeChar = 0 | currentChar;
 
@@ -136,7 +135,7 @@ void UtilsNormalizeText(char *string, const char *input, uint16_t max_len)
 
         if (unicodeChar >= 0x20 && unicodeChar <= 0x7E) {
             string[strIdx++] = (char) unicodeChar;
-        } else if (unicodeChar >= 0xC0 && unicodeChar <= 0x017f) {
+        } else if (unicodeChar >= 0xC0 && unicodeChar <= 0x017F) {
             string[strIdx++] = utils_char_latin[unicodeChar-0xC0];
         } else if (unicodeChar >= 0xC280 && unicodeChar <= 0xC3BF) {
             if (language == CONFIG_SETTING_LANGUAGE_RUSSIAN &&
@@ -144,9 +143,8 @@ void UtilsNormalizeText(char *string, const char *input, uint16_t max_len)
             ) {
                 transStr = UtilsTransliterateExtendedASCIIToASCII(unicodeChar);
                 transStrLength = strlen(transStr);
-                if (strIdx+transStrLength>=max_len) break;
 
-                if (transStrLength != 0) {
+                if ((transStrLength != 0)&&(strIdx+transStrLength<(max_len-1))) {
                     for (transIdx = 0; transIdx < transStrLength; transIdx++) {
                         string[strIdx++] = (char)transStr[transIdx];
                     }
@@ -155,7 +153,7 @@ void UtilsNormalizeText(char *string, const char *input, uint16_t max_len)
                 // Convert UTF-8 byte to Unicode then check if it falls within
                 // the range of extended ASCII
                 uint32_t extendedChar = (unicodeChar & 0xFF) + ((unicodeChar >> 8) - 0xC2) * 64;
-                if (extendedChar >= 0xC0 && extendedChar <= 0x017f) {
+                if (extendedChar >= 0xC0 && extendedChar <= 0x017F) {
                     string[strIdx++] = utils_char_latin[extendedChar-0xC0];
                 }
             }

--- a/firmware/application/lib/utils.h
+++ b/firmware/application/lib/utils.h
@@ -182,7 +182,7 @@ typedef struct UtilsAbstractDisplayValue_t {
     int8_t timeout;
 } UtilsAbstractDisplayValue_t;
 UtilsAbstractDisplayValue_t UtilsDisplayValueInit(char *, uint8_t);
-void UtilsNormalizeText(char *, const char *);
+void UtilsNormalizeText(char *, const char *, uint16_t);
 void UtilsRemoveSubstring(char *, const char *);
 void UtilsReset();
 void UtilsSetRPORMode(uint8_t, uint16_t);


### PR DESCRIPTION
Based on https://www.ucas.com/sites/default/files/extended-character-sets-substitutions.pdf and https://stackoverflow.com/a/10831704 I adapted the code into BlueBus, to provide a better display of Extended Latin characters in metadata.

Still more room for playing around, e.g. for things that can be interpreted with multiple characters - like  1/4, 1/2, ss,  and others, where the framework is there already but that would need more constants and code writing. 