### PR TITLE
add two IKE text display functions

### DIFF
--- a/firmware/application/lib/ibus.c
+++ b/firmware/application/lib/ibus.c
@@ -1798,6 +1798,91 @@ void IBusCommandIKEText(IBus_t *ibus, char *message)
     );
 }
 
+/*
+ * IBusCommandIKETextAsCCM()
+ *     Description:
+ *          Send text to the IKE display as sender CCM 
+ *          Message is persistant, does not disappear until revoke command is sent
+ *     Params:
+ *          IBus_t *ibus     The pointer to the IBus_t object
+ *          char *message    Text which should be displayed at the IKE
+ *                          Max 20 chars, will be filled up with spaces 0x20   
+ *     Returns:
+ *          void
+ */
+void IBusCommandIKETextAsCCM(IBus_t *ibus, char *message)
+{
+    unsigned char displayText[23];
+    displayText[0] = 0x1A; // Unknown
+    displayText[1] = 0x35; // Display without GONG
+    displayText[2] = 0x00; // Display without GONG
+    
+    uint8_t idx;
+    for (idx = 0; idx < 20; idx++) 
+    {
+        // Check if message is long enough, otherwise fill up with blanks 0x20
+        if(idx < strlen(message))
+        {
+            displayText[idx + 3] = message[idx];
+        }
+        else
+        {
+            displayText[idx + 3] = 0x20;
+        }        
+    }
+    IBusSendCommand(
+        ibus,
+        IBUS_DEVICE_CCM,
+        IBUS_DEVICE_IKE,
+        displayText,
+        sizeof(displayText)
+    );
+}
+
+/*
+ * IBusCommandIKETextAsRAD()
+ *     Description:
+ *          Send text to the IKE display as sender RAD
+ *          Message disappears itself after certain time (5? or 10s)
+ *     Params:
+ *          IBus_t *ibus    The pointer to the IBus_t object
+ *          char *message   Text which should be displayed at the IKE
+ *                          Max 20 chars, will be filled up with spaces 0x20   
+ *     Returns:
+ *          void
+ */
+void IBusCommandIKETextAsRAD(IBus_t *ibus, char *message)
+{
+    unsigned char displayText[strlen(message) + 4];
+    displayText[0] = 0x23; 
+    displayText[1] = 0x62;
+    displayText[2] = 0x30;  // Display without GONG 
+    displayText[3] = 0x07;     
+    uint8_t idx;    
+    
+    // Copy each char to be displayed in the payload
+    for (idx = 0; idx < 20; idx++) 
+    {
+        // Check if message is long enough, otherwise fill up with blanks 0x20
+        if(idx < strlen(message))
+        {
+            displayText[idx + 4] = message[idx];
+        }
+        else
+        {
+            displayText[idx + 4] = 0x20;
+        }        
+    }
+   
+    IBusSendCommand(
+        ibus,
+        IBUS_DEVICE_RAD,
+        IBUS_DEVICE_IKE,
+        displayText,
+        sizeof(displayText)
+    );
+}
+
 /**
  * IBusCommandIKETextClear()
  *     Description:

--- a/firmware/application/lib/ibus.h
+++ b/firmware/application/lib/ibus.h
@@ -486,6 +486,8 @@ void IBusCommandIKEGetIgnitionStatus(IBus_t *);
 void IBusCommandIKEGetVehicleType(IBus_t *);
 void IBusCommandIKESetTime(IBus_t *, uint8_t, uint8_t);
 void IBusCommandIKEText(IBus_t *, char *);
+void IBusCommandIKETextAsCCM(IBus_t *, char *);
+void IBusCommandIKETextAsRAD(IBus_t *, char *);
 void IBusCommandIKETextClear(IBus_t *);
 void IBusCommandLMActivateBulbs(IBus_t *, unsigned char, unsigned char);
 void IBusCommandLMGetClusterIndicators(IBus_t *);


### PR DESCRIPTION
There are 2 ecus which also support writing on the text display of the IKE: RAD and CCM (aka the LCM). 

The message of the LCM/CCM must be deleted manually (that is what happens originally when releasing the check control button at the IKE). The message of the RAD can (contrary to all available documentation) also display 20 chars. 
Both functions fill up shorter messages with trailing 0x20 spaces.

The existing IKE function always displayed a trailing "3" for me.

I personally use these functions to display a welcome message on ignition change.
![grafik](https://user-images.githubusercontent.com/91900310/137204406-b4b52b22-5377-4625-ab47-b4866426c297.png)

Here we have to discuss how this can be saved in the EEPROM + editable for the end user, might be content of further commits.
