### PR TITLE
fix: remove inconsistency between IGN "ALWAYSON" and "ON" options; allow blind audio transmission

### DIFF
--- a/firmware/application/handler/handler_ibus.c
+++ b/firmware/application/handler/handler_ibus.c
@@ -193,6 +193,7 @@ void HandlerIBusInit(HandlerContext_t *context)
     );
     if (ConfigGetSetting(CONFIG_SETTING_IGN_ALWAYS_ON) == CONFIG_SETTING_ON) {
         IBusSetInternalIgnitionStatus(context->ibus, IBUS_IGNITION_KL15);
+        context->ibus->cdChangerFunction = IBUS_CDC_FUNC_PLAYING;
     }
 }
 

--- a/firmware/application/ui/cli.c
+++ b/firmware/application/ui/cli.c
@@ -894,6 +894,14 @@ void CLIProcess()
                     } else if (UtilsStricmp(msgBuf[2], "ALWAYSON") == 0) {
                         if (UtilsStricmp(msgBuf[3], "ON") == 0) {
                             ConfigSetSetting(CONFIG_SETTING_IGN_ALWAYS_ON, CONFIG_SETTING_ON);
+                            uint8_t ignitionStatus = 0x01;
+                            IBusCommandIKESetIgnitionStatus(cli.ibus, ignitionStatus);
+                            EventTriggerCallback(
+                                IBUS_EVENT_IKE_IGNITION_STATUS,
+                                (uint8_t *)&ignitionStatus
+                            );
+                            cli.ibus->cdChangerFunction = IBUS_CDC_FUNC_PLAYING;
+                            cli.ibus->ignitionStatus = 1;
                         } else if (UtilsStricmp(msgBuf[3], "OFF") == 0) {
                             ConfigSetSetting(CONFIG_SETTING_IGN_ALWAYS_ON, CONFIG_SETTING_OFF);
                         } else {


### PR DESCRIPTION
Currently, `SET IGN ON` and `SET IGN ALWAYSON ON` are not congruent: the former also starts playback, whereas the latter does not. This PR makes `SET IGN ALWAYSON ON` start playback as well:

`handler_ibus.c`**: when `CONFIG_SETTING_IGN_ALWAYS_ON` is enabled, set `cdChangerFunction` to `IBUS_CDC_FUNC_PLAYING` at init so audio streams immediately.
`cli.c`**: when the user runs `SET IGN ALWAYSON ON`, apply the same ignition status update and event trigger as `SET IGN ON`, and start playback, so the setting takes effect without a reboot.

This allows limited functionality of the module without an I-bus connection (e.g. on a pre-1998 E38). When configured with `IGN ALWAYSON ON`, the module will stream audio even if no response from the I-bus is received.